### PR TITLE
Explicitly reference 1.0.0.0 of System.Web.WebPages and System.Web.Helpers

### DIFF
--- a/WebGitNet/WebGitNet.csproj
+++ b/WebGitNet/WebGitNet.csproj
@@ -54,8 +54,8 @@
     </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
-    <Reference Include="System.Web.WebPages" />
-    <Reference Include="System.Web.Helpers" />
+    <Reference Include="System.Web.WebPages, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Web.Helpers, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />


### PR DESCRIPTION
This allows the development machine to install higher versions of MVC framework side-by-side without failing applications targeting old MVC

Without this, the application fails after installing MVC4
