### PR TITLE
add git notes ref type

### DIFF
--- a/WebGitNet.SharedLib/GitRef.cs
+++ b/WebGitNet.SharedLib/GitRef.cs
@@ -18,6 +18,7 @@ namespace WebGitNet
         Tag,
         RemoteBranch,
         Stash,
+        Notes,
     }
 
     public class GitRef
@@ -27,6 +28,7 @@ namespace WebGitNet
             { RefType.Branch, "refs/heads" },
             { RefType.Tag,    "refs/tags" },
             { RefType.RemoteBranch, "refs/remotes" },
+            { RefType.Notes, "refs/notes" },
         };
 
         public GitRef(string shaId, string refPath)


### PR DESCRIPTION
Hi,

I've been using WebGitNet for awhile and recently started using git's notes in the repo. 
WebGitNet stopped working for me. So I've found out what was the issue - it misses "refs/notes" git ref type support. I added it and this fixed the problem. 

The change is very minor.

Thanks for great application!
