### PR TITLE
When using Subgit (Synchronisation between Git and Subversion) the commi...

### DIFF
--- a/WebGitNet.SharedLib/GitRef.cs
+++ b/WebGitNet.SharedLib/GitRef.cs
@@ -17,6 +17,7 @@ namespace WebGitNet
         RemoteBranch,
         Stash,
         Notes,
+        Svn
     }
 
     public class GitRef
@@ -27,6 +28,7 @@ namespace WebGitNet
             { RefType.Tag,    "refs/tags" },
             { RefType.RemoteBranch, "refs/remotes" },
             { RefType.Notes, "refs/notes" },
+            { RefType.Svn, "refs/svn" },//Reference created by subgit. Fot internal use. So when found skip.
         };
 
         public GitRef(string shaId, string refPath)
@@ -36,6 +38,7 @@ namespace WebGitNet
 
             foreach (var prefix in prefixes)
             {
+                //Skip for internal subgit use
                 if (refPath.StartsWith(prefix.Value))
                 {
                     this.Name = refPath.Substring(prefix.Value.Length + 1);

--- a/WebGitNet/Web.config
+++ b/WebGitNet/Web.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0"?>
 <configuration>
   <appSettings>
-    <add key="RepositoriesPath" value="C:\Repos\Git" />
+    <add key="RepositoriesPath" value="C:\SourceDotNet\TstSubVerGit\SourceDotNet" />
     <add key="GitCommand" value="C:\Program Files (x86)\Git\bin\git.exe" />
     <add key="GravatarFallBack" value="wavatar" />
     <add key="Markdown.AutoHyperlink" value="true" />

--- a/WebGitNet/WebGitNet.csproj
+++ b/WebGitNet/WebGitNet.csproj
@@ -76,7 +76,9 @@
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
-    <Reference Include="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Web.Services" />
     <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
@@ -230,6 +232,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Properties\PublishProfiles\Local folder.pubxml" />
     <None Include="Scripts\jquery.unobtrusive-ajax.js" />
     <None Include="Scripts\jquery.validate.js" />
     <None Include="Scripts\jquery.validate.unobtrusive.js" />


### PR DESCRIPTION
...t took long and the SVN refs where visible.

Added SVN as reftype to prevent error.
Added check for end of stream to prevent long wait for replication to subversion.
